### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+examples
+test
+.travis.yml
+Makefile
+.gitignore


### PR DESCRIPTION
This will reduce the size of [the npm distribution](https://www.npmjs.com/package/relp), as tests and examples do not need to be distributed with the package through npm. 
